### PR TITLE
Minor tweaks to some default settings in map

### DIFF
--- a/master/map.jinja
+++ b/master/map.jinja
@@ -25,6 +25,9 @@
                 ]
             }
         ],
+        'saltpad': {
+            'install_dir': '/var/www/saltpad'
+        }
     },
     'Debian': {
         'pkgs': [
@@ -53,7 +56,7 @@
             'libffi-devel',
         ],
     },
-}, grain='os_family', merge=salt.pillar.get('salt_master:lookup'), base='default') %}
+}, grain='os_family', merge=salt.pillar.get('salt_master:overrides'), base='default') %}
 
 {% set master_ssl = salt['grains.filter_by']({
     'default': {

--- a/master/saltpad.sls
+++ b/master/saltpad.sls
@@ -7,7 +7,7 @@ install_nginx_on_master:
 
 saltpad-archive:
   archive.extracted:
-    - name: {{ master.saltpad.install_dir}}
+    - name: {{ master.saltpad.install_dir }}
     - source: https://github.com/Lothiraldan/saltpad/releases/download/{{ master.saltpad.version }}/dist.zip
     - source_hash: sha1=https://github.com/Lothiraldan/saltpad/releases/download/{{ master.saltpad.version }}/dist.zip.sha1
     - archive_format: zip

--- a/master/templates/aws.conf
+++ b/master/templates/aws.conf
@@ -6,7 +6,7 @@
   {% if provider.get('security_group', None) -%}
   securitygroup: {{ provider.security_group }}
   {% endif -%}
-  private_key: {{ provider.private_key_path }}/{{provider.keyname}}
+  private_key: {{ provider.private_key_path }}
   driver: ec2
   {% for arg, val in provider.get('extra_params', {}).items() -%}
   {{ arg }}: {{ val }}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,5 +7,3 @@ then
 fi
 sudo mkdir -p /srv/salt
 sudo mkdir -p /srv/pillar
-sudo mkdir -p /srv/formulas
-# sudo cp minion.conf /etc/salt/minion.d/minion.conf


### PR DESCRIPTION
- Updated merge target from `lookup` to `overrides`
- Added install_dir setting for saltpad
- Fixed issue with aws template for ssh key path