### PR TITLE
Add salt-proxy systemd service

### DIFF
--- a/master/config.sls
+++ b/master/config.sls
@@ -32,3 +32,15 @@ include:
         - service: salt_master_running
     - makedirs: True
 {% endfor %}
+
+{% for proxyid in salt.pillar.get('salt_master:proxy_configs:apps') %}
+/etc/systemd/system/{{ proxyid }}.service:
+  file.managed:
+    - name: /etc/systemd/system/{{ proxyid }}.service
+    - source: salt://master/templates/salt_proxy.service
+    - template: jinja
+  cmd.run:
+    - name: systemctl daemon-reload
+    - onchanges:
+        - file: /etc/systemd/system/{{ proxyid }}.service
+{% endfor %}

--- a/master/config.sls
+++ b/master/config.sls
@@ -36,11 +36,10 @@ include:
 {% for proxyid in salt.pillar.get('salt_master:proxy_configs:apps') %}
 /etc/systemd/system/{{ proxyid }}.service:
   file.managed:
-    - name: /etc/systemd/system/{{ proxyid }}.service
+    - name: /etc/systemd/system/{{ proxyid }}@.service
     - source: salt://master/templates/salt_proxy.service
-    - template: jinja
   cmd.run:
     - name: systemctl daemon-reload
     - onchanges:
-        - file: /etc/systemd/system/{{ proxyid }}.service
+        - file: /etc/systemd/system/{{ proxyid }}@.service
 {% endfor %}

--- a/master/config.sls
+++ b/master/config.sls
@@ -33,13 +33,17 @@ include:
     - makedirs: True
 {% endfor %}
 
-{% for proxyid in salt.pillar.get('salt_master:proxy_configs:apps') %}
-/etc/systemd/system/{{ proxyid }}.service:
+/etc/systemd/system/salt-proxy.service:
   file.managed:
-    - name: /etc/systemd/system/{{ proxyid }}@.service
+    - name: /etc/systemd/system/salt-proxy@.service
     - source: salt://master/templates/salt_proxy.service
   cmd.run:
     - name: systemctl daemon-reload
     - onchanges:
-        - file: /etc/systemd/system/{{ proxyid }}@.service
+        - file: /etc/systemd/system/salt-proxy@.service
+
+{% for proxyid in salt.pillar.get('salt_master:proxy_configs:apps') %}
+enable_salt_proxy_{{proxyid}}:
+  cmd.run:
+    - name: systemctl enable -now salt-proxy@{{ proxyid }}.service
 {% endfor %}

--- a/master/config.sls
+++ b/master/config.sls
@@ -44,6 +44,7 @@ include:
 
 {% for proxyid in salt.pillar.get('salt_master:proxy_configs:apps') %}
 enable_salt_proxy_{{proxyid}}:
-  cmd.run:
-    - name: systemctl enable -now salt-proxy@{{ proxyid }}.service
+  service.running:
+    - name: salt-proxy@{{ proxyid }}.service
+    - enable: True
 {% endfor %}

--- a/master/templates/salt_proxy.service
+++ b/master/templates/salt_proxy.service
@@ -1,0 +1,11 @@
+[Unit]
+Description={{ proxyid }} proxy minion
+After=syslog.target
+
+[Service]
+ExecStart=/usr/bin/salt-proxy --proxyid={{ proxyid }} --daemon --log-file=/var/log/salt/{{ proxyid }}.log
+Restart=always
+KillSignal=SIGQUIT
+
+[Install]
+WantedBy=multi-user.target

--- a/master/templates/salt_proxy.service
+++ b/master/templates/salt_proxy.service
@@ -1,9 +1,9 @@
 [Unit]
-Description={{ proxyid }} proxy minion
+Description=%i proxy minion
 After=syslog.target
 
 [Service]
-ExecStart=/usr/bin/salt-proxy --proxyid={{ proxyid }} --daemon --log-file=/var/log/salt/{{ proxyid }}.log
+ExecStart=/usr/bin/salt-proxy --proxyid=%i --daemon --log-file=/var/log/salt/%i.log
 Restart=always
 KillSignal=SIGQUIT
 


### PR DESCRIPTION
#### What are the relevant tickets?
Part of [Issue#857](https://github.com/mitodl/salt-ops/issues/857)

#### What's this PR do?
- Adds a salt-proxy systemd service template
- Adds directive to config to generate systemd service files based on all salt-proxy apps listed in salt-master pillar.